### PR TITLE
fix: 영화 목록이 보이지 않는 이슈(#32)

### DIFF
--- a/frontend/src/components/main/MovieSlide.jsx
+++ b/frontend/src/components/main/MovieSlide.jsx
@@ -15,11 +15,11 @@ export const MovieSlide = ({ title, genre }) => {
         if(genre === null)
         {
             getPopularFromApi()
-                .then(res => {setMovies(res)})
+                .then(res => {setMovies(res.content);})
                 .catch(console.error);
         }else{
             getPopularByGenreFromApi(genre)
-                .then(res => {setMovies(res); console.log(res)})
+                .then(res => {setMovies(res.content);})
                 .catch(console.error);
         }
     }, []);


### PR DESCRIPTION
### 관련 이슈
- Close #32: 영화 목록이 보이지 않는 문제

### 변경 사항
- MovieSlide 컴포넌트에서 API 응답 파싱 시 res → res.content로 수정
- JSON 데이터가 정상적으로 파싱되지 않아 발생하던 렌더링 오류를 해결
- 수정 후 영화 목록이 정상적으로 렌더링됨을 확인

### 테스트 내역
- 영화 목록이 정상적으로 UI에 표시되는지 확인
- API 응답이 정상적으로 파싱되는지 콘솔 로그로 검증
- 영화 데이터가 없는 경우에도 오류 없이 동작하는지 테스트

### 기타 참고 사항
- 원인은 API 응답 객체를 그대로 파싱하려다 발생한 JSON 파싱 오류이며, res.content로 접근하여 해결
