### PR TITLE
fix: 로그인 회원가입 오류 메시지 수정 및 중복 처리 수정

### DIFF
--- a/backend/backend/src/main/java/org/dfpl/lecture/db/backend/controller/AuthController.java
+++ b/backend/backend/src/main/java/org/dfpl/lecture/db/backend/controller/AuthController.java
@@ -11,12 +11,17 @@ import org.dfpl.lecture.db.backend.util.JwtUtil;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("/api/auth")
 public class AuthController {
+
+    record Message(String message) {}
+    record Error(String error)   {}
 
     private final AuthService authService;
     private final AuthenticationManager authenticationManager;
@@ -46,24 +51,33 @@ public class AuthController {
 
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody LoginRequest request) {
-        authenticationManager.authenticate(
-                new UsernamePasswordAuthenticationToken(
-                        request.getEmail(),
-                        request.getPassword()
-                )
-        );
+        try {
+            // 1) 인증 시도 (이메일이 없거나, 비번 불일치하면 BadCredentialsException 발생)
+            authenticationManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(
+                            request.getEmail(),
+                            request.getPassword()
+                    )
+            );
+        } catch (BadCredentialsException ex) {
+            // 2) 인증 실패 시 JSON 에러 바디와 함께 401 리턴
+            return ResponseEntity
+                    .status(HttpStatus.UNAUTHORIZED)
+                    .body(new Error("이메일 또는 비밀번호가 일치하지 않습니다."));
+        }
 
-        User user = userRepository.findByEmail(request.getEmail()).orElseThrow();
+        // 3) 인증에 성공했어도, 혹시 이메일 조회가 실패하면 동일한 메시지를 던져줍니다.
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.UNAUTHORIZED,
+                        "이메일 또는 비밀번호가 일치하지 않습니다."
+                ));
+
+        // 4) 토큰 생성 후 정상 응답
         String token = jwtUtil.generateToken(
                 user.getEmail(),
                 List.of("USER")
         );
         return ResponseEntity.ok(Map.of("token", token));
-    }
-
-    record Message(String message) {
-    }
-
-    record Error(String error) {
     }
 }


### PR DESCRIPTION
-존재하지 않는 이메일 또는 잘못된 비밀번호 둘 다 BadCredentialsException으로 잡아 401 + {"error":"이메일 또는 비밀번호가 일치하지 않습니다."} 형태로 수정

-프론트에서 response.json()해도 유효한 JSON이 오므로 Unexpected end of JSON input 에러 사라짐

Close #37