### PR TITLE
Fix/backend score int to double

### DIFF
--- a/backend/backend/src/main/java/org/dfpl/lecture/db/backend/config/WebConfig.java
+++ b/backend/backend/src/main/java/org/dfpl/lecture/db/backend/config/WebConfig.java
@@ -9,7 +9,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:5176") // React dev server
+                .allowedOrigins("http://localhost:5173") // React dev server
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true);

--- a/backend/backend/src/main/java/org/dfpl/lecture/db/backend/dto/MyReviewDTO.java
+++ b/backend/backend/src/main/java/org/dfpl/lecture/db/backend/dto/MyReviewDTO.java
@@ -6,10 +6,10 @@ import lombok.Data;
 public class MyReviewDTO {
     private Long reviewId;
     private Long movieId;
-    private Integer score;
+    private Double score;
     private String content;
 
-    public MyReviewDTO(Long reviewId, Long movieId, int score, String content) {
+    public MyReviewDTO(Long reviewId, Long movieId, Double score, String content) {
         this.reviewId = reviewId;
         this.movieId = movieId;
         this.score = score;

--- a/backend/backend/src/main/java/org/dfpl/lecture/db/backend/dto/ReviewRequest.java
+++ b/backend/backend/src/main/java/org/dfpl/lecture/db/backend/dto/ReviewRequest.java
@@ -5,6 +5,6 @@ import lombok.Data;
 @Data
 public class ReviewRequest {
     private Long movieId;
-    private Integer score;    // null 허용
+    private Double score;    // null 허용
     private String content;
 }

--- a/backend/backend/src/main/java/org/dfpl/lecture/db/backend/dto/ReviewResponse.java
+++ b/backend/backend/src/main/java/org/dfpl/lecture/db/backend/dto/ReviewResponse.java
@@ -2,7 +2,7 @@ package org.dfpl.lecture.db.backend.dto;
 
 public record ReviewResponse(
         String movieTitle,
-        Integer    score,
+        Double    score,
         String content,
         String authorNickname
 ) {}

--- a/backend/backend/src/main/java/org/dfpl/lecture/db/backend/entity/Review.java
+++ b/backend/backend/src/main/java/org/dfpl/lecture/db/backend/entity/Review.java
@@ -19,7 +19,7 @@ public class Review {
     private Long id;
 
     @Column(nullable = true)
-    private Integer score;
+    private Double score;
 
     @Column(nullable = true)
     private String content;

--- a/backend/backend/src/main/java/org/dfpl/lecture/db/backend/service/MovieService.java
+++ b/backend/backend/src/main/java/org/dfpl/lecture/db/backend/service/MovieService.java
@@ -291,12 +291,14 @@ public class MovieService {
     }
 
     private SearchResultDTO toSearchResultDto(MovieDB entity) {
+        Double rawVote = entity.getVoteAverage();
+        double halfVote = (rawVote != null ? rawVote / 2.0 : 0.0);
         return new SearchResultDTO(
                 entity.getId(),
                 entity.getTitle(),
                 entity.getReleaseDate(),
                 entity.getPosterUrl(),
-                entity.getVoteAverage()
+                halfVote
         );
     }
 
@@ -479,7 +481,7 @@ public class MovieService {
         }
 
         // TMDB 평점 + 투표 수
-        dto.setVoteAverage(movieObj.get("vote_average").getAsDouble());
+        dto.setVoteAverage(movieObj.get("vote_average").getAsDouble() / 2.0);
         dto.setVoteCount(movieObj.get("vote_count").getAsInt());
 
         // 장르 리스트 (genres 배열에서 name만 추출)

--- a/backend/backend/src/main/java/org/dfpl/lecture/db/backend/service/MovieService.java
+++ b/backend/backend/src/main/java/org/dfpl/lecture/db/backend/service/MovieService.java
@@ -247,48 +247,6 @@ public class MovieService {
         }
     }
 
-    /**
-     * 엔티티 → DTO 변환 헬퍼
-     */
-    private MovieSummaryDTO toSummaryDto(MovieDB entity) {
-        MovieSummaryDTO dto = new MovieSummaryDTO();
-        dto.setId(entity.getId());
-        dto.setTitle(entity.getTitle());
-        dto.setOriginalTitle(entity.getOriginalTitle());
-        dto.setOverview(entity.getOverview());
-        dto.setPopularity(entity.getPopularity());
-        dto.setReleaseDate(entity.getReleaseDate());
-        dto.setVoteAverage(entity.getVoteAverage());
-        dto.setVoteCount(entity.getVoteCount());
-        dto.setPosterUrl(entity.getPosterUrl());
-        dto.setBackdropUrl(entity.getBackdropUrl());
-
-        // genre1~genre4 컬럼을 한곳에 모아서 List<GenreDTO> 생성
-        List<GenreDTO> genres = new ArrayList<>();
-        if (entity.getGenre1() != null) {
-            Long gid = entity.getGenre1();
-            String name = GenreMappingUtil.GENRE_ID_TO_NAME.get(gid);
-            if (name != null) genres.add(new GenreDTO(gid, name));
-        }
-        if (entity.getGenre2() != null) {
-            Long gid = entity.getGenre2();
-            String name = GenreMappingUtil.GENRE_ID_TO_NAME.get(gid);
-            if (name != null) genres.add(new GenreDTO(gid, name));
-        }
-        if (entity.getGenre3() != null) {
-            Long gid = entity.getGenre3();
-            String name = GenreMappingUtil.GENRE_ID_TO_NAME.get(gid);
-            if (name != null) genres.add(new GenreDTO(gid, name));
-        }
-        if (entity.getGenre4() != null) {
-            Long gid = entity.getGenre4();
-            String name = GenreMappingUtil.GENRE_ID_TO_NAME.get(gid);
-            if (name != null) genres.add(new GenreDTO(gid, name));
-        }
-        dto.setGenres(genres);
-
-        return dto;
-    }
 
     private SearchResultDTO toSearchResultDto(MovieDB entity) {
         Double rawVote = entity.getVoteAverage();
@@ -340,90 +298,7 @@ public class MovieService {
     }
 
 
-    /**
-     * TMDB /search/movie API 호출 → 결과를 MovieSummaryDTO 리스트로 반환
-     */
-    public List<MovieSummaryDTO> searchMovies(String query, int page) throws IOException {
-        // 1) 검색어 URL 인코딩
-        String encoded = URLEncoder.encode(query, StandardCharsets.UTF_8);
 
-        // 2) /search/movie 엔드포인트 구성 (language=ko-KR 포함)
-        String endpoint = "/search/movie"
-                + "?query=" + encoded
-                + "&page=" + page
-                + "&language=ko-KR";
-
-        // 3) TMDB 호출
-        JsonObject root = fetchJson(endpoint);
-        JsonArray results = root.getAsJsonArray("results");
-
-        List<MovieSummaryDTO> list = new ArrayList<>();
-        if (results != null) {
-            for (JsonElement elem : results) {
-                JsonObject obj = elem.getAsJsonObject();
-
-                MovieSummaryDTO dto = new MovieSummaryDTO();
-                dto.setId(obj.get("id").getAsLong());
-                dto.setTitle(obj.get("title").getAsString());
-                dto.setOriginalTitle(obj.get("original_title").getAsString());
-                dto.setOverview(obj.get("overview").getAsString());
-                dto.setPopularity(obj.get("popularity").getAsDouble());
-                dto.setReleaseDate(obj.get("release_date").getAsString());
-                dto.setVoteAverage(obj.get("vote_average").getAsDouble());
-                dto.setVoteCount(obj.get("vote_count").getAsInt());
-
-                // poster_path → full URL
-                if (obj.has("poster_path") && !obj.get("poster_path").isJsonNull()) {
-                    String posterPath = obj.get("poster_path").getAsString();
-                    dto.setPosterUrl(TmdbApiUtil.getPosterImageUrl(posterPath));
-                }
-                // backdrop_path → full URL
-                if (obj.has("backdrop_path") && !obj.get("backdrop_path").isJsonNull()) {
-                    String backdropPath = obj.get("backdrop_path").getAsString();
-                    dto.setBackdropUrl(TmdbApiUtil.getBackdropImageUrl(backdropPath));
-                }
-
-                // 4) genre_ids → List<GenreDTO> 매핑
-                List<GenreDTO> genreList = new ArrayList<>();
-                if (obj.has("genre_ids") && obj.get("genre_ids").isJsonArray()) {
-                    JsonArray genreIdsArr = obj.getAsJsonArray("genre_ids");
-                    for (JsonElement idElem : genreIdsArr) {
-                        long genreId = idElem.getAsLong();
-                        String name = GenreMappingUtil.GENRE_ID_TO_NAME.get(genreId);
-                        if (name != null) {
-                            genreList.add(new GenreDTO(genreId, name));
-                        }
-                    }
-                }
-                dto.setGenres(genreList);
-
-                list.add(dto);
-            }
-        }
-
-        return list;
-    }
-
-    /**
-     * TMDB Search API로 검색한 결과를 DB에 저장하지 않고, 그대로 DTO 리스트만 반환하려면 위 메서드를 사용하세요.
-     */
-
-
-    /**
-     * DB에 저장된 영화 전체를 popularity DESC 순으로 페이징 조회
-     */
-    public Page<MovieDB> getPopularMovies(int page, int size) {
-        Pageable pageable = PageRequest.of(page - 1, size);
-        return movieRepository.findAllByOrderByPopularityDesc(pageable);
-    }
-
-    /**
-     * “genre1~genre4 중 하나라도 genreId와 일치하는 영화”를 popularity DESC 순으로 페이징 조회
-     */
-    public Page<MovieDB> getPopularByGenre(Long genreId, int page, int size) {
-        Pageable pageable = PageRequest.of(page - 1, size);
-        return movieRepository.findByGenreIdOrderByPopularityDesc(genreId, pageable);
-    }
 
 
     /**

--- a/backend/backend/src/main/java/org/dfpl/lecture/db/backend/service/ReviewService.java
+++ b/backend/backend/src/main/java/org/dfpl/lecture/db/backend/service/ReviewService.java
@@ -27,7 +27,7 @@ public class ReviewService {
                 .map(r -> new ReviewResponse(
                         r.getMovie().getTitle(),
                         // null-safe 처리 추가
-                        r.getScore() != null ? r.getScore() : 0,
+                        r.getScore() != null ? r.getScore() : 0.0,
                         r.getContent(),
                         r.getUser().getNickname()
                 ))
@@ -58,7 +58,7 @@ public class ReviewService {
         Review review = Review.builder()
                 .movie(movie)
                 .user(user)
-                .score(request.getScore())
+                .score(Double.valueOf(request.getScore()))
                 .content(request.getContent())
                 .build();
 

--- a/backend/backend/src/main/java/org/dfpl/lecture/db/backend/service/ReviewService.java
+++ b/backend/backend/src/main/java/org/dfpl/lecture/db/backend/service/ReviewService.java
@@ -63,7 +63,20 @@ public class ReviewService {
                 .build();
 
         Review saved = reviewRepository.save(review);
+
+        if(request.getScore() != null){
+            Double oldAvg = movie.getVoteAverage() != null ? movie.getVoteAverage() : 0.0;
+            Integer oldCount = movie.getVoteCount()  != null ? movie.getVoteCount()  : 0;
+            Double halfOldAvg = oldAvg / 2.0;
+            Double newHalfAvg = (halfOldAvg * oldCount + request.getScore()) / (oldCount + 1);
+            movie.setVoteAverage(newHalfAvg);
+            movie.setVoteCount(oldCount + 1);
+            movieRepository.save(movie);
+        }
+
         return saved.getId();
+
+
     }
 
     public void delete(Long reviewId, User currentUser) {

--- a/backend/backend/src/main/java/org/dfpl/lecture/db/backend/service/UserService.java
+++ b/backend/backend/src/main/java/org/dfpl/lecture/db/backend/service/UserService.java
@@ -33,7 +33,7 @@ public class UserService {
                 .map(r -> new MyReviewDTO(
                         r.getId(),
                         r.getMovie().getId(),
-                        r.getScore() != null ? r.getScore() : 0,
+                        r.getScore() != null ? r.getScore() : 0.0,
                         r.getContent()
                 ))
                 .collect(Collectors.toList());


### PR DESCRIPTION
# Pull Request: 사용자 평점 통계 로직 개선 및 타입 안정화

## 변경 내용
- **fix**: `int` → `double` 타입 변경  
  - `Review.score`, DTO 매핑, 삼항 연산식 기본값을 `0.0`으로 처리  
  - `getVoteAverage()` null 체크 추가  
- **feat**: 리뷰 저장 시 `MovieDB.voteAverage`·`voteCount` 갱신  
  - 수식:  
    ```text
    halfOldAvg = oldAvg/2
    newHalfAvg = (halfOldAvg * oldCount + newScore) / (oldCount + 1)
    ```  

## 구현 요약
1. **ReviewService**  
   - 리뷰 저장 후 기존 `voteAverage`, `voteCount` 조회  
   - 위 수식으로 평균 계산 후 `movie.setVoteAverage(...)`, `movie.setVoteCount(...)`  
   - `movieRepository.save(movie)` 호출
2. **DTO 매핑**  
   - `toSearchResultDto()` 등에서 null-safe하게 `/ 2.0` 처리  

## 테스트
- **단위 테스트**  
  - 첫 리뷰 등록 → `voteCount=1`, `voteAverage=newScore/2`  
  - 기존 리뷰 누적 → 공식대로 평균 계산  
- **통합 테스트**  
  - `POST /api/reviews` 실행 후  
    ```sql
    SELECT vote_average, vote_count FROM movie_db WHERE id = :movieId;
    ```  
