### PR TITLE
feat: 영화 리뷰 content와 score 분리

### DIFF
--- a/backend/backend/src/main/java/org/dfpl/lecture/db/backend/config/SecurityConfig.java
+++ b/backend/backend/src/main/java/org/dfpl/lecture/db/backend/config/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig {
                 .cors(Customizer.withDefaults())
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        // 1) 인증 없이 열어줄 엔드포인트
+                        // 인증 없이 열어줄 엔드포인트
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers(HttpMethod.GET,
                                 "/api/movies/**",
@@ -42,17 +42,17 @@ public class SecurityConfig {
                                 "/api/movies/detail/**"
                         ).permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/movies/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/reviews/movies/**").permitAll()
 
-                        // 2) USER 권한이 필요한 엔드포인트
-                        .requestMatchers(HttpMethod.POST,   "/api/reviews/**").hasRole("USER")
-                        .requestMatchers(HttpMethod.DELETE, "/api/reviews/**").hasRole("USER")
-                        .requestMatchers(HttpMethod.GET,    "/api/users/me", "/api/users/me/**")
-                        .hasRole("USER")
-                        .requestMatchers(HttpMethod.POST,   "/api/users/me/favorites/**").hasRole("USER")
-                        .requestMatchers(HttpMethod.DELETE,"/api/users/me/favorites/**").hasRole("USER")
-                        .requestMatchers(HttpMethod.POST,   "/api/like").hasRole("USER")
+                        // 리뷰 관련은 인증만 되어 있으면 통과
+                        .requestMatchers("/api/reviews/**").authenticated()
 
-                        // 3) 위에 걸리지 않는 모든 요청은 인증만 있으면 OK
+                        // 유저 개인 정보는 USER 권한 필요
+                        .requestMatchers("/api/users/me/**").hasRole("USER")
+                        .requestMatchers(HttpMethod.POST, "/api/users/me/favorites/**").hasRole("USER")
+                        .requestMatchers(HttpMethod.DELETE, "/api/users/me/favorites/**").hasRole("USER")
+
+                        // 그 외 나머지 요청은 인증만 있으면 OK
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
@@ -60,7 +60,6 @@ public class SecurityConfig {
 
         return http.build();
     }
-
 
     @Bean
     public PasswordEncoder passwordEncoder() {

--- a/backend/backend/src/main/java/org/dfpl/lecture/db/backend/controller/ReviewController.java
+++ b/backend/backend/src/main/java/org/dfpl/lecture/db/backend/controller/ReviewController.java
@@ -1,10 +1,12 @@
 package org.dfpl.lecture.db.backend.controller;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.dfpl.lecture.db.backend.dto.ReviewRequest;
 import org.dfpl.lecture.db.backend.dto.ReviewResponse;
+import org.dfpl.lecture.db.backend.entity.Review;
 import org.dfpl.lecture.db.backend.entity.User;
 import org.dfpl.lecture.db.backend.repository.UserRepository;
 import org.dfpl.lecture.db.backend.service.ReviewService;
@@ -14,6 +16,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PatchMapping;
 
 @RestController
 @RequestMapping("/api/reviews")
@@ -22,28 +25,6 @@ public class ReviewController {
 
     private final ReviewService reviewService;
     private final UserRepository userRepository;
-
-    @PostMapping
-    @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<?> create(
-            @RequestBody ReviewRequest req,
-            Authentication authentication          // Spring Security Authentication 객체
-    ) {
-        // 1) 토큰에서 꺼낸 사용자 이름(이메일)
-        String email = authentication.getName();
-
-        // 2) DB에서 JPA User 엔티티 조회
-        User currentUser = userRepository.findByEmail(email)
-                .orElseThrow(() -> new UsernameNotFoundException(email));
-
-        // 3) 서비스에 위임
-        Long reviewId = reviewService.create(currentUser, req);
-
-        return ResponseEntity.ok(Map.of(
-                "message", "리뷰가 등록되었습니다.",
-                "reviewId", reviewId
-        ));
-    }
 
 
     @DeleteMapping("/{reviewId}")
@@ -65,5 +46,23 @@ public class ReviewController {
     ) {
         List<ReviewResponse> reviews = reviewService.findByMovieId(movieId);
         return ResponseEntity.ok(reviews);
+    }
+
+    @PostMapping
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> upsert(
+            @RequestBody ReviewRequest req,
+            Authentication authentication
+    ) {
+        User user = userRepository.findByEmail(authentication.getName())
+                .orElseThrow(() -> new UsernameNotFoundException(authentication.getName()));
+        Review saved = reviewService.upsertReview(user, req);
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("reviewId", saved.getId());
+        if (req.getScore() != null)   body.put("score",   saved.getScore());
+        if (req.getContent() != null) body.put("content", saved.getContent());
+
+        return ResponseEntity.ok(body);
     }
 }

--- a/backend/backend/src/main/java/org/dfpl/lecture/db/backend/repository/ReviewRepository.java
+++ b/backend/backend/src/main/java/org/dfpl/lecture/db/backend/repository/ReviewRepository.java
@@ -1,10 +1,13 @@
 package org.dfpl.lecture.db.backend.repository;
 
 import java.util.List;
+import java.util.Optional;
+import org.dfpl.lecture.db.backend.entity.MovieDB;
 import org.dfpl.lecture.db.backend.entity.Review;
 import org.dfpl.lecture.db.backend.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> findAllByUser(User user);
     List<Review> findAllByMovie_Id(Long movieId);
+    Optional<Review> findByUserAndMovie(User user, MovieDB movie);
 }


### PR DESCRIPTION
-@PatchMapping("/api/reviews") → @PostMapping("") 변경
PATCH 미지원으로 403 에러 발생하던 문제 해결
-단일 upsert() 메서드로 리뷰 생성/수정 로직 통합
ReviewService#upsertReview 호출
응답 바디 포맷 개선
항상 reviewId 반환
요청에 포함된 score/content 필드만 선택적으로 포함
-보안 설정 강화
@PreAuthorize("isAuthenticated()") 추가로 인증된 사용자만 요청 가능
Authentication 객체에서 이메일로 User 조회 후 서비스에 전달

