### PR TITLE
feat:기존의 장르 탐색 방식을 mn매핑 방식으로 변경

### DIFF
--- a/backend/backend/src/main/java/org/dfpl/lecture/db/backend/config/GenreAndMovieGenreLoader.java
+++ b/backend/backend/src/main/java/org/dfpl/lecture/db/backend/config/GenreAndMovieGenreLoader.java
@@ -1,0 +1,81 @@
+package org.dfpl.lecture.db.backend.config;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.dfpl.lecture.db.backend.entity.Genre;
+import org.dfpl.lecture.db.backend.entity.MovieDB;
+import org.dfpl.lecture.db.backend.entity.MovieGenre;
+import org.dfpl.lecture.db.backend.entity.MovieGenreId;
+import org.dfpl.lecture.db.backend.repository.GenreRepository;
+import org.dfpl.lecture.db.backend.repository.MovieGenreRepository;
+import org.dfpl.lecture.db.backend.repository.MovieRepository;
+import org.dfpl.lecture.db.backend.util.GenreMappingUtil;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class GenreAndMovieGenreLoader implements CommandLineRunner {
+
+    private final GenreRepository genreRepo;
+    private final MovieRepository movieRepo;
+    private final MovieGenreRepository movieGenreRepo;
+
+    @Override
+    @Transactional
+    public void run(String... args) throws Exception {
+        // 이미 한 번 매핑이 되어 있으면 전체 로직 건너뛰기
+        if (movieGenreRepo.count() > 0) {
+            return;
+        }
+
+        // 1) Genre 테이블 채우기 (없을 때만)
+        GenreMappingUtil.GENRE_ID_TO_NAME.forEach((id, name) -> {
+            if (!genreRepo.existsById(id)) {
+                genreRepo.save(Genre.builder()
+                        .id(id)
+                        .name(name)
+                        .build());
+            }
+        });
+
+        // 2) MovieGenre 조인 테이블 채우기
+        List<MovieDB> movies = movieRepo.findAll();
+
+        // 이미 매핑된 PK 집합 (방지용)
+        Set<MovieGenreId> existing = movieGenreRepo.findAll().stream()
+                .map(MovieGenre::getId)
+                .collect(Collectors.toSet());
+
+        List<MovieGenre> toSave = new ArrayList<>();
+        for (MovieDB movie : movies) {
+            List<Long> genreIds = Arrays.asList(
+                    movie.getGenre1(),
+                    movie.getGenre2(),
+                    movie.getGenre3(),
+                    movie.getGenre4()
+            );
+            for (Long gid : genreIds) {
+                if (gid == null) continue;
+                MovieGenreId pk = new MovieGenreId(movie.getId(), gid);
+                if (existing.contains(pk)) continue;
+
+                Genre genre = genreRepo.findById(gid)
+                        .orElseThrow(() -> new IllegalStateException("Unknown Genre ID: " + gid));
+
+                toSave.add(MovieGenre.builder()
+                        .id(pk)
+                        .movie(movie)
+                        .genre(genre)
+                        .build());
+            }
+        }
+
+        if (!toSave.isEmpty()) {
+            movieGenreRepo.saveAll(toSave);
+        }
+    }
+}

--- a/backend/backend/src/main/java/org/dfpl/lecture/db/backend/entity/Genre.java
+++ b/backend/backend/src/main/java/org/dfpl/lecture/db/backend/entity/Genre.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.dfpl.lecture.db.backend.dto.GenreDTO;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -24,4 +25,12 @@ public class Genre {
 
     @Column(nullable = false, length = 100)
     private String name;
+
+    @OneToMany(
+            mappedBy = "genre",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true
+    )
+
+    private List<MovieGenre> movieGenres = new ArrayList<>();
 }

--- a/backend/backend/src/main/java/org/dfpl/lecture/db/backend/entity/MovieDB.java
+++ b/backend/backend/src/main/java/org/dfpl/lecture/db/backend/entity/MovieDB.java
@@ -51,5 +51,13 @@ public class MovieDB {
 
     @Column(name = "genre4")
     private Long genre4;
+
+    // ★ 조인 엔티티만 남기기
+    @OneToMany(
+            mappedBy = "movie",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true
+    )
+    private List<MovieGenre> movieGenres = new ArrayList<>();
 }
 

--- a/backend/backend/src/main/java/org/dfpl/lecture/db/backend/entity/MovieGenre.java
+++ b/backend/backend/src/main/java/org/dfpl/lecture/db/backend/entity/MovieGenre.java
@@ -1,0 +1,27 @@
+package org.dfpl.lecture.db.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "movie_genre_legend")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MovieGenre {
+
+    @EmbeddedId
+    private MovieGenreId id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("movieId")
+    @JoinColumn(name = "movie_id")
+    private MovieDB movie;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("genreId")
+    @JoinColumn(name = "genre_id")
+    private Genre genre;
+}

--- a/backend/backend/src/main/java/org/dfpl/lecture/db/backend/entity/MovieGenreId.java
+++ b/backend/backend/src/main/java/org/dfpl/lecture/db/backend/entity/MovieGenreId.java
@@ -1,0 +1,17 @@
+package org.dfpl.lecture.db.backend.entity;
+
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+import java.io.Serializable;
+
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class MovieGenreId implements Serializable {
+    private Long movieId;
+    private Long genreId;
+}

--- a/backend/backend/src/main/java/org/dfpl/lecture/db/backend/repository/MovieGenreRepository.java
+++ b/backend/backend/src/main/java/org/dfpl/lecture/db/backend/repository/MovieGenreRepository.java
@@ -1,0 +1,12 @@
+package org.dfpl.lecture.db.backend.repository;
+
+import org.dfpl.lecture.db.backend.entity.MovieGenre;
+import org.dfpl.lecture.db.backend.entity.MovieGenreId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MovieGenreRepository extends JpaRepository<MovieGenre, MovieGenreId> {
+}

--- a/backend/backend/src/main/java/org/dfpl/lecture/db/backend/repository/MovieRepository.java
+++ b/backend/backend/src/main/java/org/dfpl/lecture/db/backend/repository/MovieRepository.java
@@ -21,13 +21,11 @@ public interface MovieRepository extends JpaRepository<MovieDB, Long> {
      *    popularity 내림차순으로 페이징 조회
      */
     @Query("""
-        SELECT m 
-        FROM MovieDB m 
-        WHERE m.genre1 = :genreId 
-           OR m.genre2 = :genreId 
-           OR m.genre3 = :genreId 
-           OR m.genre4 = :genreId
-        ORDER BY m.popularity DESC
+        SELECT m
+          FROM MovieDB m
+          JOIN m.movieGenres mg
+         WHERE mg.genre.id = :genreId
+         ORDER BY m.popularity DESC
         """)
     Page<MovieDB> findByGenreIdOrderByPopularityDesc(
             @Param("genreId") Long genreId,

--- a/backend/backend/src/main/java/org/dfpl/lecture/db/backend/service/MovieService.java
+++ b/backend/backend/src/main/java/org/dfpl/lecture/db/backend/service/MovieService.java
@@ -293,6 +293,7 @@ public class MovieService {
             Long genreId, int page, int size
     ) {
         Pageable pageable = PageRequest.of(page - 1, size);
+        // 여기가 조인 버전으로 바뀐 메서드를 호출하게 됩니다
         Page<MovieDB> entityPage = movieRepository.findByGenreIdOrderByPopularityDesc(genreId, pageable);
         return entityPage.map(this::toSearchResultDto);
     }


### PR DESCRIPTION
# PR: 영화–장르 Many-To-Many 매핑 리팩토링

## 1. 개요
- 기존 `movie_db_hard` 테이블의 `genre1`–`genre4` 칼럼을 이용한 OR 조건 조회  
  → 정규화된 조인 테이블(`movie_genre_legend`) 기반 Many-To-Many 매핑으로 전환  
- 기대 효과  
  - 인덱스 기반 필터링으로 조회 성능 개선  
  - 스키마 확장성 및 유지보수성 강화  

---

## 2. 주요 변경 사항

### 2.1 엔티티 구조 리팩토링

| 엔티티      | 변경 전                                    | 변경 후                                                 |
|-----------|------------------------------------------|--------------------------------------------------------|
| **MovieDB** | `@ManyToMany` → OR 조건조회(`genre1`–`genre4`) | - `@ManyToMany` 제거<br>- `@OneToMany movieGenres` 추가<br>- `genre1`–`genre4` `@Deprecated` |
| **Genre**   | 단독 테이블                                | `@OneToMany movieGenres` 추가                          |
| **MovieGenre** | 없음                                     | - 신규 엔티티 생성<br>- `@EmbeddedId MovieGenreId`<br>- `@MapsId` + `@ManyToOne` 연관관계 |

### 2.2 Repository

```java
public interface MovieRepository extends JpaRepository<MovieDB, Long> {

    // 전체 인기 영화
    Page<MovieDB> findAllByOrderByPopularityDesc(Pageable pageable);

    // 장르별 인기 영화 (Many-To-Many 조인)
    @Query("""
        SELECT m
          FROM MovieDB m
          JOIN m.movieGenres mg
         WHERE mg.genre.id = :genreId
         ORDER BY m.popularity DESC
        """)
    Page<MovieDB> findByGenreIdOrderByPopularityDesc(
        @Param("genreId") Long genreId,
        Pageable pageable
    );
}
