### PR TITLE
fix: 로그인 응답에 user 객체 추가 및 프론트 data.user 접근 로직 수정

### DIFF
--- a/backend/backend/src/main/java/org/dfpl/lecture/db/backend/controller/AuthController.java
+++ b/backend/backend/src/main/java/org/dfpl/lecture/db/backend/controller/AuthController.java
@@ -78,6 +78,16 @@ public class AuthController {
                 user.getEmail(),
                 List.of("USER")
         );
-        return ResponseEntity.ok(Map.of("token", token));
+
+        Map<String, Object> responseBody = Map.of(
+                "token", token,
+                "user", Map.of(
+                        "userId", user.getId(),
+                    "userNickname", user.getNickname(),
+                    "userEmail", user.getEmail()
+                )
+        );
+
+        return ResponseEntity.ok(responseBody);
     }
 }

--- a/frontend/src/components/ui/LoginDialog.jsx
+++ b/frontend/src/components/ui/LoginDialog.jsx
@@ -34,10 +34,16 @@ export function LoginDialog({ open, setOpen, onSwitch }) {
       }
 
       localStorage.setItem("token", data.token);
+      localStorage.setItem("user", JSON.stringify(data.user));
+
       setIsLoggedIn(true);
       setUser(data.user);
+
+      console.log(data.user);
+
       alert("로그인 성공!");
       setOpen(false);
+
     } catch (err) {
       alert("로그인 중 오류 발생: " + err.message);
     }

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -7,9 +7,13 @@ export const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null)
 
   useEffect(() => {
-    const token = localStorage.getItem("token")
+    const token = localStorage.getItem("token");
+    const savedUser = localStorage.getItem("user");
     if (token) {
       setIsLoggedIn(true)
+      if (savedUser) {
+        setUser(JSON.parse(savedUser));
+      }
       // 나중에 사용자 정보도 불러오면 여기서 setUser() 하면 됨
     } else {
       setIsLoggedIn(false)
@@ -19,6 +23,7 @@ export const AuthProvider = ({ children }) => {
 
   const logout = () => {
     localStorage.removeItem("token")
+    localStorage.removeItem("user");
     setIsLoggedIn(false)
     setUser(null)
   }


### PR DESCRIPTION
### 개요
- 로그인 시 백엔드에서 토큰만 반환하던 구조를 수정하여, 사용자 정보(userId, userNickname, userEmail)를 함께 포함하도록 변경
- 프론트엔드에서는 해당 응답 구조에 맞춰 data.user를 기반으로 상태를 설정하도록 수정

### 변경 사항
#### 백엔드
- AuthController.login()에서 Map<String, Object> 형태로 응답 반환
- 토큰 외에 사용자 정보 포함

#### 프론트엔드
- 로그인 성공 시 setUser(res.data.user)로 사용자 상태 설정
- 이후 페이지에서 user.userId, user.userNickname 등의 접근 가능

### 문제 해결
- 기존에는 data.user가 없어서 로그인 이후 사용자 정보 초기화 및 별점 렌더링에 실패함
- 응답 구조 및 초기 상태 설정 문제 모두 해결됨