### PR TITLE
fix: 마이페이지에서 리뷰와 즐찾 개수 제한 삭제

### DIFF
--- a/backend/backend/src/main/java/org/dfpl/lecture/db/backend/controller/UserController.java
+++ b/backend/backend/src/main/java/org/dfpl/lecture/db/backend/controller/UserController.java
@@ -80,7 +80,6 @@ public class UserController {
 
         List<FavoriteMovieDTO> top3Favs = allFavs.stream()
                 .sorted(Comparator.comparing(Favorite::getCreatedAt).reversed())
-                .limit(3)
                 .map(fav -> new FavoriteMovieDTO(
                         fav.getMovie().getId(),
                         fav.getMovie().getTitle(),

--- a/backend/backend/src/main/java/org/dfpl/lecture/db/backend/service/UserService.java
+++ b/backend/backend/src/main/java/org/dfpl/lecture/db/backend/service/UserService.java
@@ -24,12 +24,10 @@ public class UserService {
     private final FavoriteRepository favoriteRepository;
 
     public MyPageDTO getMyPage(User user) {
-        // (1) 리뷰 개수 + 최신 3개 가져오기
         List<Review> all = reviewRepository.findAllByUser(user);
         long reviewCount = all.size();
         List<MyReviewDTO> recent = all.stream()
                 .sorted(Comparator.comparing(Review::getCreatedAt).reversed())
-                .limit(3)
                 .map(r -> new MyReviewDTO(
                         r.getId(),
                         r.getMovie().getId(),
@@ -38,13 +36,11 @@ public class UserService {
                 ))
                 .collect(Collectors.toList());
 
-        // (2) 즐겨찾기 목록 가져오기 → favoriteRepository를 통해 DB 조회
         List<Favorite> allFavs = favoriteRepository.findAllByUser(user);
         long favoriteCount = allFavs.size();
 
         List<FavoriteMovieDTO> top3Favs = allFavs.stream()
                 .sorted(Comparator.comparing(Favorite::getCreatedAt).reversed())
-                .limit(3)
                 .map(fav -> new FavoriteMovieDTO(
                         fav.getMovie().getId(),
                         fav.getMovie().getTitle(),


### PR DESCRIPTION
##  변경 사항
- `UserService.getMyPage()` 에서 리뷰, 즐겨찾기 목록에 적용된 `.limit(3)` 호출 제거  
- `UserController.myPage()` 에서 즐겨찾기 DTO 변환 단계의 `.limit(3)` 호출 제거  
- 결과적으로 `/api/users/me` 응답에 **전체** 리뷰 및 즐겨찾기 목록이 포함

##  적용 파일
- `UserService.java`  
- `UserController.java` 