### PR TITLE
feat: 404 페이지 및 존재하지 않는 영화 접근 처리 개선 

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.511.0",
+        "path-to-regexp": "^8.2.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-icons": "^5.5.0",
@@ -2934,6 +2935,15 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,13 +11,13 @@
     "preview": "vite preview"
   },
   "dependencies": {
-
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.511.0",
+    "path-to-regexp": "^8.2.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",

--- a/frontend/src/components/common/404.jsx
+++ b/frontend/src/components/common/404.jsx
@@ -6,7 +6,7 @@ export default function NotFound({
         emoji = "🔍"
     }) {
     return (
-        <div className="flex flex-col items-center justify-center text-center pb-10 h-full px-4 text-gray-600 h-dvh">
+        <div className="flex flex-col items-center justify-center text-center pb-10 px-4 text-gray-600 h-dvh">
             <div className="text-3xl mb-4">{emoji}</div>
             <h2 className="text-xl font-bold mb-2">{title}</h2>
             <p className="text-sm text-gray-400">{description}</p>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,13 +1,24 @@
 import React from "react"
 import ReactDOM from "react-dom/client"
-import { BrowserRouter, useRoutes } from "react-router-dom"
+import {BrowserRouter, useLocation, useRoutes} from "react-router-dom"
 import routes from "~react-pages"
 import App from "./App" // 여기에서 공통 레이아웃, Provider 묶음
 import "./App.css";
+import NotFound from "@/pages/404.jsx";
 
 const Router = () => {
-    const element = useRoutes(routes)
-    return <App>{element}</App>
+    const element = useRoutes([
+        ...routes,
+        {
+            path: "*",
+            element: <NotFound />
+        }
+    ]);
+
+    const location = useLocation();
+    const is404 = location.pathname === "/404" || location.pathname === "*" || !routes.some(route => location.pathname.startsWith(`/${route.path}`));
+
+    return is404 ? element : <App>{element}</App>;
 }
 
 ReactDOM.createRoot(document.getElementById("root")).render(

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,27 @@
 import React from "react"
 import ReactDOM from "react-dom/client"
-import {BrowserRouter, useLocation, useRoutes} from "react-router-dom"
+import {BrowserRouter, useRoutes} from "react-router-dom"
 import routes from "~react-pages"
+import NotFound from "@/components/common/404.jsx";
+import { match } from "path-to-regexp";
 import App from "./App" // 여기에서 공통 레이아웃, Provider 묶음
 import "./App.css";
-import NotFound from "@/pages/404.jsx";
+
+const extractPaths = (routes, basePath = "") => {
+    const paths = [];
+
+    for (const route of routes) {
+        const fullPath = basePath + (route.path ? `/${route.path}` : "");
+        if (route.element) {
+            paths.push(fullPath.replace(/\/+/g, "/")); // 중복 슬래시 제거
+        }
+        if (route.children) {
+            paths.push(...extractPaths(route.children, fullPath));
+        }
+    }
+
+    return paths;
+};
 
 const Router = () => {
     const element = useRoutes([
@@ -15,8 +32,11 @@ const Router = () => {
         }
     ]);
 
-    const location = useLocation();
-    const is404 = location.pathname === "/404" || location.pathname === "*" || !routes.some(route => location.pathname.startsWith(`/${route.path}`));
+    const allPaths = extractPaths(routes);
+    const is404 = !allPaths.some((path) => {
+        const matcher = match(path, { decode: decodeURIComponent });
+        return matcher(location.pathname);
+    });
 
     return is404 ? element : <App>{element}</App>;
 }

--- a/frontend/src/pages/404.jsx
+++ b/frontend/src/pages/404.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+export default function NotFound({
+        title = "페이지를 찾을 수 없습니다",
+        description = "요청하신 페이지가 존재하지 않거나 삭제되었습니다.",
+        emoji = "🔍"
+    }) {
+    return (
+        <div className="flex flex-col items-center justify-center text-center pb-10 h-full px-4 text-gray-600 h-dvh">
+            <div className="text-3xl mb-4">{emoji}</div>
+            <h2 className="text-xl font-bold mb-2">{title}</h2>
+            <p className="text-sm text-gray-400">{description}</p>
+        </div>
+    );
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,14 +3,16 @@ import react from '@vitejs/plugin-react'
 import path from 'path'
 import { fileURLToPath } from 'url'
 import Pages from "vite-plugin-pages"
+
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
 export default defineConfig({
-  plugins: [react(),
+  plugins: [
+    react(),
     Pages({
       dirs: "src/pages",
-      extensions: ["jsx"],
+      extensions: ["jsx"]
     })
   ],
   resolve: {
@@ -21,7 +23,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:8080', // Spring Boot 서버 주소
+        target: 'http://localhost:8080',
         changeOrigin: true,
         secure: false,
       },


### PR DESCRIPTION
- 잘못된 경로 접근 시 Header, Footer가 노출되지 않도록 처리
- 유효하지 않은 라우트일 경우 NotFound 컴포넌트 반환
- 존재하지 않는 영화 ID로 접근 시 403 응답 받아 404 페이지로 navigate 처리
- 공통 레이아웃은 유효한 라우트일 때만 감싸도록 수정
- vite-plugin-pages를 활용한 자동 라우트 목록 활용