### PR TITLE
fix: 영화 상세 정보를 불러올 때 유저 토큰을 전달하지 않아 isFavorite 값이 누락되던 문제를 수정함

### DIFF
--- a/frontend/src/components/moive/detail/RatingBar.jsx
+++ b/frontend/src/components/moive/detail/RatingBar.jsx
@@ -6,30 +6,19 @@ import RatingActions from "./RatingActions";
 import { ReviewModal } from "@/components/ui/ReviewModal.jsx";
 import { AuthContext } from "@/context/AuthContext.jsx";
 
-export default function RatingBar({ voteAverage, movieId = null, userScore}) {
+export default function RatingBar({ voteAverage, movieId = null, isFavorite = null, userScore}) {
     // 1) 초기 average를 서버에서 받은 voteAverage로 설정
     const [average, setAverage] = useState(voteAverage); // 전체 평균
     // 2) 서버에 저장된 좋아요 여부를 불러와 초기화 (선택)
-    const [liked, setLiked] = useState(false);
+    const [liked, setLiked] = useState(isFavorite);
     const [modalOpen, setModalOpen] = useState(false);
 
     const { isLoggedIn } = useContext(AuthContext);
     // 페이지 로드 시, 내가 좋아요 누른 상태인지 확인
     useEffect(() => {
-
-        if (!isLoggedIn || movieId == null) return;
-
-        const token = localStorage.getItem("token");
-        Promise.all([
-            fetch("/api/users/me/favorites", {
-                headers: { "Authorization": `Bearer ${token}` }
-            }).then(res => res.ok ? res.json() : []),
-        ])
-            .then(([favorites]) => {
-                setLiked(favorites.some(f => f.movieId === movieId));
-            })
-            .catch(console.error);
-    }, [isLoggedIn, movieId]);
+        if(isFavorite)
+            setLiked(isFavorite);
+    }, [isFavorite]);
 
     const handleRate = async (rating) => {
         if (!isLoggedIn) return alert("로그인이 필요합니다!");

--- a/frontend/src/pages/api/movieApi.js
+++ b/frontend/src/pages/api/movieApi.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import {authFetch} from "@/context/AuthContext.jsx";
 
 const API_BASE = '/api/movies';
 
@@ -8,8 +9,9 @@ const API_BASE = '/api/movies';
  * @returns {Promise<MovieDetailDTO>}
  */
 export const getMovieDetail = async (id) => {
-    const res = await axios.get(`${API_BASE}/detail/${id}`);
-    return res.data;
+    const res = await authFetch(`${API_BASE}/detail/${id}`);
+    if (!res.ok) throw new Error("Failed to fetch movie detail");
+    return res.json();
 };
 
 /**

--- a/frontend/src/pages/movie/detail/[movieId]/index.jsx
+++ b/frontend/src/pages/movie/detail/[movieId]/index.jsx
@@ -14,6 +14,8 @@ import AllCommentsModal from "@/components/moive/detail/AllCommentsModal.jsx";
 import {AuthContext} from "@/context/AuthContext.jsx";
 
 export default function MovieDetailPage() {
+    const { user } = useContext(AuthContext);
+
     const { movieId } = useParams();
     const [movie, setMovie] = useState(null);
     const [comments, setComments] = useState([]);
@@ -22,7 +24,6 @@ export default function MovieDetailPage() {
     const [loading, setLoading] = useState(true);
     const [userScore, setUserScore] = useState(null); // 내 점수
 
-    const { user } = useContext(AuthContext);
     const navigate = useNavigate();
 
     const fetchComments = async () => {
@@ -34,10 +35,8 @@ export default function MovieDetailPage() {
         }
     };
 
-    const effectRan = useRef(false);
+
     useEffect(() => {
-        if (effectRan.current) return;
-        effectRan.current = true;
         if (!movieId) return;
 
         const fetchData = async () => {


### PR DESCRIPTION
## 변경 내용
- 영화 상세 정보를 불러올 때 유저 토큰이 전달되지 않아 `isFavorite` 값이 누락되던 문제를 수정했습니다.
- 유저 인증이 필요한 API 요청에 토큰을 포함하도록 수정했습니다.

## 테스트
- 로그인 상태에서 영화 상세 정보를 요청 시 `isFavorite` 값이 정상적으로 반환되는지 확인했습니다.
- 비로그인 상태에서는 기존과 동일하게 `isFavorite` 값이 없는 응답이 반환되는지 확인했습니다.
